### PR TITLE
Fix: Show Graphs With Smaller Values

### DIFF
--- a/static/js/conference/components/classes/graphs/jitterGraphData.js
+++ b/static/js/conference/components/classes/graphs/jitterGraphData.js
@@ -26,7 +26,7 @@ class JitterGraphData extends DataForGraphs {
       const yPoint = this._calculateJitter(stat, key);
       if (Number.isFinite(yPoint)) {
         const xPoint = this._statTimeEpoch(stat);
-        const point = [xPoint, Number(yPoint.toFixed(2))];
+        const point = [xPoint, Number(yPoint.toFixed(4))];
 
         data[stat.connection].push(point);
       }

--- a/static/js/conference/components/classes/graphs/packetLossGraphData.js
+++ b/static/js/conference/components/classes/graphs/packetLossGraphData.js
@@ -34,7 +34,7 @@ class PacketLossGraphData extends DataForGraphs {
       if (Number.isFinite(yPoint)) {
 
         const xPoint = this._statTimeEpoch(stat);
-        const point = [xPoint, Number(yPoint.toFixed(1))];
+        const point = [xPoint, Number(yPoint.toFixed(4))];
 
         data[stat.connection].push(point);
       }


### PR DESCRIPTION
# Summary 

- Update jitter and packet loss graph precision to 4 decimal places

## Motivation

The motivation behind this change is to enhance graph visibility when testing WebRTC connections on local networks, where small variations in jitter and packet loss can be significant."