### PR TITLE
fix: guard participants and issues access in chart components

### DIFF
--- a/static/js/app-dashboard/components/graphs/mostCommongIssuesChart.vue
+++ b/static/js/app-dashboard/components/graphs/mostCommongIssuesChart.vue
@@ -90,7 +90,7 @@ export default {
   methods: {
     onChartClick(e) {
       this.modalConferences = this.conferences.filter((conf) => {
-        return conf.issues.some((issue) => issue.code === this.seriesData.find(s => s.y === e.yValue).issueCode)
+        return conf.issues && conf.issues.some((issue) => issue.code === this.seriesData.find(s => s.y === e.yValue).issueCode)
       });
       this.$refs["conferencesModal"].show();
     }

--- a/static/js/app-dashboard/components/graphs/noParticipantsChart.vue
+++ b/static/js/app-dashboard/components/graphs/noParticipantsChart.vue
@@ -31,7 +31,7 @@ export default {
   computed: {
     dataSeries() {
       let arr = this.conferences.map(conf => {
-        return conf.participants.length;
+        return conf.participants ? conf.participants.length : 0;
       });
       let participants = peermetrics.utils.reduce(arr);
       let conferencesCount = this.conferences.length;


### PR DESCRIPTION
## Problem

After api#19 removed `expand_fields` from the conference list endpoint, `conference.participants` and `conference.issues` are `undefined` on list responses. Two chart components crash:

- **ParticipantsChart**: `conf.participants.length` → `TypeError: Cannot read properties of undefined (reading 'length')`
- **MostCommonIssuesChart**: `conf.issues.some(...)` on chart bar click → same error

## Fix

Added null guards to both components:
- `conf.participants ? conf.participants.length : 0`
- `conf.issues && conf.issues.some(...)`

## Test plan

- [ ] Dashboard graphs tab loads without console errors
- [ ] Number of Participants chart renders (shows 0 when participants data unavailable)
- [ ] Clicking a bar on Most Common Issues chart doesn't crash