### PR TITLE
fix: use participants_count from API for participants chart

### DIFF
--- a/static/js/app-dashboard/components/graphs/noParticipantsChart.vue
+++ b/static/js/app-dashboard/components/graphs/noParticipantsChart.vue
@@ -31,7 +31,7 @@ export default {
   computed: {
     dataSeries() {
       let arr = this.conferences.map(conf => {
-        return conf.participants ? conf.participants.length : 0;
+        return conf.participants_count || (conf.participants ? conf.participants.length : 0);
       });
       let participants = peermetrics.utils.reduce(arr);
       let conferencesCount = this.conferences.length;


### PR DESCRIPTION
## Problem

The "Number of participants" chart shows all zeros because `conf.participants` is undefined on list responses (expand_fields removed in api#19).

## Fix

Uses `conf.participants_count` (annotated integer from api#22) instead of `conf.participants.length`. Falls back to `participants.length` for conference detail views where the full array is still available.

## Dependencies

Requires peermetrics/api#22 to be deployed.

## Test plan

- [ ] "Number of participants" pie chart shows correct distribution (e.g., "2 participants: 85%")
- [ ] Chart works on both dashboard (uses participants_count) and detail views (uses participants.length)