### PR TITLE
fix: unblock conferences chart — remove v-if waiting on full conferences list

### DIFF
--- a/static/js/app-dashboard/components/graphsTab.vue
+++ b/static/js/app-dashboard/components/graphsTab.vue
@@ -3,8 +3,7 @@
     <div class="row mt-3">
       <div class="col">
         <p class="lead">Conferences</p>
-        <Loader v-if="conferences == null" />
-        <conferences-chart v-else :conferences="conferences" />
+        <conferences-chart />
       </div>
     </div>
 


### PR DESCRIPTION
## Problem

Phase 1 of #20 migrated the Conferences chart to fetch its own summary via the new \`/v1/conferences/summary\` endpoint (peermetrics/api#24). The summary returns in ~1 second, so the chart itself is fast now.

**But on production the chart still shows a spinner for ~20-40 seconds.**

Root cause: \`graphsTab.vue\` kept this guard from the old architecture:

\`\`\`html
<Loader v-if=\"conferences == null\" />
<conferences-chart v-else :conferences=\"conferences\" />
\`\`\`

\`conferences\` is the parent \`app.vue\`'s \`conferences\` ref. It only becomes non-null after the full \`/v1/conferences\` call finishes — **38 MB / 22 seconds on production**. Other charts still need that data, so \`app.vue\` still fetches it.

The chart is already self-sufficient — it fetches its own summary in \`mounted()\` — but the template prevented it from mounting until the unrelated blocking call finished.

## Fix

Drop the v-if and the prop. The chart manages its own state.

\`\`\`html
<conferences-chart />
\`\`\`

## Measured in local test

- Chart renders in ~1s from page load (was waiting on the 22s conferences call before)
- No regression in functionality