### PR TITLE
docs: update browser SDK snippet to pinned jsDelivr URL

### DIFF
--- a/app/templates/account/organization.html
+++ b/app/templates/account/organization.html
@@ -121,7 +121,7 @@
                                                 To use it directly in the browser, just add the snippet near the end of the body tag
                                               </p>
                                               <code>
-                                                <pre class="language-html"><code>&lt;script src=&quot;//cdn.peermetrics.io/js/sdk/peermetrics.min.js&quot;&gt;&lt;/script&gt;</code></pre>
+                                                <pre class="language-html"><code>&lt;script src=&quot;https://cdn.jsdelivr.net/npm/@peermetrics/sdk@2.8.0/dist/browser.min.js&quot;&gt;&lt;/script&gt;</code></pre>
                                               </code>
                                             </li>
                                           </ul>

--- a/app/templates/welcome.html
+++ b/app/templates/welcome.html
@@ -145,7 +145,7 @@
                                     To use it directly in the browser, just add the snippet near the end of the body tag
                                   </p>
                                   <code>
-                                    <pre class="language-html"><code>&lt;script src=&quot;//cdn.peermetrics.io/js/sdk/peermetrics.min.js&quot;&gt;&lt;/script&gt;</code></pre>
+                                    <pre class="language-html"><code>&lt;script src=&quot;https://cdn.jsdelivr.net/npm/@peermetrics/sdk@2.8.0/dist/browser.min.js&quot;&gt;&lt;/script&gt;</code></pre>
                                   </code>
                                 </li>
                               </ul>


### PR DESCRIPTION
Replace legacy cdn.peermetrics.io script examples with a pinned @peermetrics/sdk@2.8.0 jsDelivr URL in onboarding snippets for welcome and organization pages.