### PR TITLE
feat: migrate duration / participants / issues / gum charts to summary endpoints (Phase 2 + 3 of #20)

### DIFF
--- a/static/js/app-dashboard/components/graphs/conferenceDurationChart.vue
+++ b/static/js/app-dashboard/components/graphs/conferenceDurationChart.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="chart">
-    <NoDataMessage v-if="seriesData.length < 1" />
+    <Loader v-if="loading" />
+    <NoDataMessage v-else-if="isEmpty" />
     <bar-chart
         v-else
         id="conference-duration-chartjs"
@@ -22,78 +23,111 @@
 import NoDataMessage from "../../../components/noDataMessage.vue";
 import ConferenceListModal from "../../../components/conferenceListModal.vue";
 import BarChart from "../../../components/barChart.vue";
+import Loader from "../../../components/loader.vue";
 
 export default {
   name: "conference-duration-chart",
-  props: {
-    conferences: {
-      type: Array,
-      required: true
-    },
-  },
   components: {
     BarChart,
     NoDataMessage,
     ConferenceListModal,
+    Loader,
   },
 
   data() {
     return {
+      loading: true,
+      summary: [],
       modalConferences: [],
     };
   },
 
   computed: {
-    durations() {
-      // create an array with all the conf durations
-      let confDurations = this.conferences.map((conference) => {
-        return {
-          value: conference.duration / 60,
-          data: conference.id
-        }
-      });
-
-      return peermetrics.utils.groupDurations(
-        confDurations,
-        peermetrics.globals.durationInterval
-      );
-    },
     categories() {
-      return this.durations.map(n => n.title);
-    },
-    seriesData() {
-      const durations = this.durations.reduce((accumulator, currentValue) => accumulator + currentValue.number, 0)
-
-      if (durations) {
-        return {
-          data: this.durations.map((n) => n.number),
-          values: this.durations.map((n) => new Set(n.data))
-        };
-      } else {
-        return [];
-      }
+      return this.summary.map((b) => b.range);
     },
     series() {
       return [
         {
           label: "Conferences",
-          data: this.seriesData.data,
+          data: this.summary.map((b) => b.count),
           backgroundColor: peermetrics.colors.info,
-          values: this.seriesData.values
-        }
+        },
       ];
-    }
+    },
+    isEmpty() {
+      return this.summary.every((b) => b.count === 0);
+    },
+  },
+
+  async mounted() {
+    await this.fetchSummary();
   },
 
   methods: {
-    onChartClick(e) {
-      this.modalConferences = this.conferences.filter((conf) => {
-        return this.seriesData.values[e.index].has(conf.id)
-      });
+    async fetchSummary() {
+      this.loading = true;
+      try {
+        const since = new Date();
+        since.setDate(since.getDate() - peermetrics.daysHistory);
+        const res = await peermetrics.get(peermetrics.urls.conferencesDurationSummary, {
+          appId: peermetrics.app.id,
+          created_at_gte: since.toISOString(),
+        });
+        this.summary = Object.freeze(Array.isArray(res) ? res : (res.data || []));
+      } catch (e) {
+        console.warn(e);
+        this.summary = [];
+      }
+      this.loading = false;
+    },
 
+    async onChartClick(e) {
+      const bucket = this.summary[e.index];
+      if (!bucket) return;
+
+      try {
+        this.modalConferences = await this.fetchAllInBucket(bucket);
+      } catch (err) {
+        console.warn(err);
+        this.modalConferences = [];
+      }
       this.$refs["conferencesModal"].show();
-    }
-  }
+    },
+
+    async fetchAllInBucket(bucket) {
+      const since = new Date();
+      since.setDate(since.getDate() - peermetrics.daysHistory);
+
+      const PAGE_SIZE = 200;
+      const out = [];
+      let offset = 0;
+      let total = Infinity;
+
+      const baseParams = {
+        appId: peermetrics.app.id,
+        created_at_gte: since.toISOString(),
+        duration_gte: bucket.min_sec,
+      };
+      if (bucket.max_sec !== null && bucket.max_sec !== undefined) {
+        baseParams.duration_lt = bucket.max_sec;
+      }
+
+      while (offset < total) {
+        const res = await peermetrics.get(peermetrics.urls.conferences(), {
+          ...baseParams,
+          limit: PAGE_SIZE,
+          offset,
+        });
+        const page = res.results || [];
+        total = typeof res.count === "number" ? res.count : page.length;
+        out.push(...page);
+        if (page.length === 0) break;
+        offset += page.length;
+      }
+      return out;
+    },
+  },
 };
 </script>
 

--- a/static/js/app-dashboard/components/graphs/gumChart.vue
+++ b/static/js/app-dashboard/components/graphs/gumChart.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="chart">
-    <NoDataMessage v-if="dataSeries.length===0" />
+    <Loader v-if="loading" />
+    <NoDataMessage v-else-if="dataSeries.length === 0" />
     <pie-chart
         v-else
         id="gum-chartjs"
@@ -14,44 +15,57 @@
 <script>
 import NoDataMessage from "../../../components/noDataMessage.vue";
 import PieChart from "../../../components/pieChart.vue";
+import Loader from "../../../components/loader.vue";
 
 export default {
   name: "gum-chart",
-  props: {
-    issues: {
-      type: Array,
-      required: true
-    }
-  },
   components: {
     PieChart,
-    NoDataMessage
+    NoDataMessage,
+    Loader,
   },
+
+  data() {
+    return {
+      loading: true,
+      summary: [],
+    };
+  },
+
   computed: {
     dataSeries() {
-      const numberOfErrors = this.issues.length
-
-      let titles = {}
-      const result = this.issues.map(function(issue) {
-        titles[issue.data.name] = issue.data.message
-        return issue.data.name
-      })
-
-      let gum_warnings = peermetrics.utils.reduce(result);
-
-      let series = [];
-
-      for (let key of Object.keys(gum_warnings)) {
-        series.push({
-          name: titles[key],
-          y: (gum_warnings[key] / numberOfErrors) * 100,
-          count: gum_warnings[key]
-        });
-      }
-
-      return series;
+      const total = this.summary.reduce((sum, row) => sum + (row.count || 0), 0);
+      if (!total) return [];
+      return this.summary.map((row) => ({
+        name: row.message || row.name,
+        y: (row.count / total) * 100,
+        count: row.count,
+      }));
     },
-  }
+  },
+
+  async mounted() {
+    await this.fetchSummary();
+  },
+
+  methods: {
+    async fetchSummary() {
+      this.loading = true;
+      try {
+        const since = new Date();
+        since.setDate(since.getDate() - peermetrics.daysHistory);
+        const res = await peermetrics.get(peermetrics.urls.issuesGumSummary, {
+          appId: peermetrics.app.id,
+          created_at_gte: since.toISOString(),
+        });
+        this.summary = Array.isArray(res) ? res : (res.data || []);
+      } catch (e) {
+        console.warn(e);
+        this.summary = [];
+      }
+      this.loading = false;
+    },
+  },
 };
 </script>
 

--- a/static/js/app-dashboard/components/graphs/mostCommongIssuesChart.vue
+++ b/static/js/app-dashboard/components/graphs/mostCommongIssuesChart.vue
@@ -75,7 +75,7 @@ export default {
           appId: peermetrics.app.id,
           created_at_gte: since.toISOString(),
         });
-        this.summary = Object.freeze(res.data || []);
+        this.summary = Object.freeze(Array.isArray(res) ? res : (res.data || []));
       } catch (e) {
         console.warn(e);
         this.summary = [];

--- a/static/js/app-dashboard/components/graphs/mostCommongIssuesChart.vue
+++ b/static/js/app-dashboard/components/graphs/mostCommongIssuesChart.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="chart">
-    <NoDataMessage v-if="seriesData.length===0 " />
+    <Loader v-if="loading" />
+    <NoDataMessage v-else-if="summary.length === 0" />
 
     <bar-chart
         v-else
@@ -25,76 +26,102 @@
 import NoDataMessage from "../../../components/noDataMessage.vue";
 import ConferenceListModal from "../../../components/conferenceListModal.vue";
 import BarChart from "../../../components/barChart.vue";
+import Loader from "../../../components/loader.vue";
 
 export default {
   name: "most-common-issues-chart",
-  props: {
-    issues: {
-      type: Array,
-      required: true
-    },
-    conferences: {
-      type: Array,
-      required: true
-    }
-  },
   components: {
     BarChart,
     NoDataMessage,
-    ConferenceListModal
+    ConferenceListModal,
+    Loader,
   },
+
   data() {
     return {
-      modalConferences: []
+      loading: true,
+      summary: [],
+      modalConferences: [],
     };
   },
-  computed: {
-    errorCodes() {
-      return this.issues.map((issue) => {
-        return issue.code
-      })
-    },
-    sortedCodes() {
-      return peermetrics.utils.reduce(this.errorCodes)
-    },
-    categories() {
-      return this.seriesData.map(s => s.title)
-    },
-    seriesData() {
-      const issues = {}
-      this.issues.forEach((issue) => {
-        issues[issue.code] = issue
-      })
 
-      return Object.keys(this.sortedCodes).map((key) => {
-        return {
-          y: this.sortedCodes[key],
-          issueCode: key,
-          title: issues[key]?.title,
-        }
-      })
-      .sort((first, second) => second.y - first.y)
+  computed: {
+    categories() {
+      return this.summary.map((row) => row.title || row.code);
     },
     series() {
       return [
         {
           label: "Issues",
-          data: this.seriesData.map(s => s.y),
+          data: this.summary.map((row) => row.count),
           backgroundColor: peermetrics.colors.info,
           barThickness: 20,
-        }
+        },
       ];
     },
   },
 
+  async mounted() {
+    await this.fetchSummary();
+  },
+
   methods: {
-    onChartClick(e) {
-      this.modalConferences = this.conferences.filter((conf) => {
-        return conf.issues && conf.issues.some((issue) => issue.code === this.seriesData.find(s => s.y === e.yValue).issueCode)
-      });
+    async fetchSummary() {
+      this.loading = true;
+      try {
+        const since = new Date();
+        since.setDate(since.getDate() - peermetrics.daysHistory);
+        const res = await peermetrics.get(peermetrics.urls.issuesSummary, {
+          appId: peermetrics.app.id,
+          created_at_gte: since.toISOString(),
+        });
+        this.summary = Object.freeze(res.data || []);
+      } catch (e) {
+        console.warn(e);
+        this.summary = [];
+      }
+      this.loading = false;
+    },
+
+    async onChartClick(e) {
+      const row = this.summary[e.index];
+      if (!row) return;
+
+      try {
+        this.modalConferences = await this.fetchConferencesForIssue(row.code);
+      } catch (err) {
+        console.warn(err);
+        this.modalConferences = [];
+      }
       this.$refs["conferencesModal"].show();
-    }
-  }
+    },
+
+    async fetchConferencesForIssue(issueCode) {
+      const since = new Date();
+      since.setDate(since.getDate() - peermetrics.daysHistory);
+
+      const PAGE_SIZE = 200;
+      const out = [];
+      let offset = 0;
+      let total = Infinity;
+
+      while (offset < total) {
+        const res = await peermetrics.get(peermetrics.urls.conferences(), {
+          appId: peermetrics.app.id,
+          created_at_gte: since.toISOString(),
+          issue_code: issueCode,
+          limit: PAGE_SIZE,
+          offset,
+        });
+        const page = res.results || [];
+        total = typeof res.count === "number" ? res.count : page.length;
+        out.push(...page);
+        if (page.length === 0) break;
+        offset += page.length;
+      }
+      return out;
+    },
+  },
 };
 </script>
 

--- a/static/js/app-dashboard/components/graphs/noParticipantsChart.vue
+++ b/static/js/app-dashboard/components/graphs/noParticipantsChart.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="chart">
-    <NoDataMessage v-if="dataSeries.length===0" />
+    <Loader v-if="loading" />
+    <NoDataMessage v-else-if="dataSeries.length === 0" />
     <pie-chart
         v-else
         id="number-of-participants-chartjs"
@@ -13,41 +14,60 @@
 <script>
 import NoDataMessage from "../../../components/noDataMessage.vue";
 import PieChart from "../../../components/pieChart.vue";
+import Loader from "../../../components/loader.vue";
 
 export default {
   name: "participants-chart",
-  props: {
-    conferences: {
-      type: Array,
-      required: true
-    }
-  },
   components: {
     PieChart,
-    NoDataMessage
+    NoDataMessage,
+    Loader,
   },
 
-  mounted() {},
+  data() {
+    return {
+      loading: true,
+      summary: [],
+    };
+  },
+
   computed: {
     dataSeries() {
-      let arr = this.conferences.map(conf => {
-        return conf.participants_count || (conf.participants ? conf.participants.length : 0);
-      });
-      let participants = peermetrics.utils.reduce(arr);
-      let conferencesCount = this.conferences.length;
-      let series = [];
+      const total = this.summary.reduce((sum, row) => sum + (row.conferences || 0), 0);
+      if (!total) return [];
+      return this.summary.map((row) => ({
+        name: String(row.participants),
+        y: (row.conferences / total) * 100,
+        count: row.conferences,
+      }));
+    },
+  },
 
-      for (let key of Object.keys(participants)) {
-        series.push({
-          name: key,
-          y: (participants[key] / conferencesCount) * 100,
-          count: participants[key]
-        });
+  async mounted() {
+    await this.fetchSummary();
+  },
+
+  methods: {
+    async fetchSummary() {
+      this.loading = true;
+      try {
+        const since = new Date();
+        since.setDate(since.getDate() - peermetrics.daysHistory);
+        const res = await peermetrics.get(
+          peermetrics.urls.conferencesParticipantCountSummary,
+          {
+            appId: peermetrics.app.id,
+            created_at_gte: since.toISOString(),
+          }
+        );
+        this.summary = Array.isArray(res) ? res : (res.data || []);
+      } catch (e) {
+        console.warn(e);
+        this.summary = [];
       }
-
-      return series;
-    }
-  }
+      this.loading = false;
+    },
+  },
 };
 </script>
 

--- a/static/js/app-dashboard/components/graphsTab.vue
+++ b/static/js/app-dashboard/components/graphsTab.vue
@@ -3,24 +3,21 @@
     <div class="row mt-3">
       <div class="col">
         <p class="lead">Conferences</p>
-        <Loader v-if="conferences == null" />
-        <conferences-chart v-else :conferences="conferences" />
+        <conferences-chart />
       </div>
     </div>
 
     <div class="row mt-3">
       <div class="col">
         <p class="lead">Most common issues</p>
-        <Loader v-if="(issues == null || conferences == null)" />
-        <most-common-issues-chart v-else :issues="issues" :conferences="conferences" />
+        <most-common-issues-chart />
       </div>
     </div>
 
     <div class="row mt-3">
       <div class="col">
         <p class="lead">Errors getting access to media</p>
-        <Loader v-if="issues == null" />
-        <gum-chart v-else :issues="gumIssues" />
+        <gum-chart />
       </div>
       <div class="col">
         <p class="lead">Relayed connections</p>
@@ -32,11 +29,7 @@
     <div class="row mt-3">
       <div class="col">
         <p class="lead">Conference duration</p>
-        <Loader v-if="conferences == null" />
-        <conference-duration-chart
-          v-else
-          :conferences="conferences"
-        />
+        <conference-duration-chart />
       </div>
     </div>
 
@@ -51,8 +44,7 @@
     <div class="row mt-3">
       <div class="col">
         <p class="lead">Number of participants</p>
-        <Loader v-if="conferences == null" />
-        <no-participants-chart v-else :conferences="conferences" />
+        <no-participants-chart />
       </div>
     </div>
 
@@ -112,7 +104,7 @@ export default {
   },
   props: {
     conferences: {
-      required: true,
+      required: false,
       validator: value => {
         return Array.isArray(value) || peermetrics.utils.isNull(value)
       }
@@ -136,17 +128,6 @@ export default {
       }
     },
   },
-  computed: {
-    gumIssues() {
-      if (this.issues) {
-        return this.issues.filter((issue) => {
-          return issue.code === 'getusermedia_error'
-        })
-      }
-
-      return []
-    }
-  }
 };
 </script>
 

--- a/static/js/peermetrics.js
+++ b/static/js/peermetrics.js
@@ -48,6 +48,10 @@
       }
     },
     conferencesSummary: '/conferences/summary',
+    conferencesDurationSummary: '/conferences/duration-summary',
+    conferencesParticipantCountSummary: '/conferences/participant-count-summary',
+    issuesSummary: '/issues/summary',
+    issuesGumSummary: '/issues/gum-summary',
     conferenceEvents: function (conferenceId) {
       if (!conferenceId) {
         throw new Error('Missing conferenceId')


### PR DESCRIPTION
## Summary
Depends on [peermetrics/api#26](https://github.com/peermetrics/api/pull/26).

Rewrites four charts to self-fetch from the new server-side summary endpoints instead of receiving a big conferences/issues array as a prop:

- \`conferenceDurationChart.vue\` → \`/conferences/duration-summary\`
  - Click-to-detail now pages matching conferences via \`duration_gte\` / \`duration_lt\` filters (up to 200 per page, no silent 50-cap)
- \`noParticipantsChart.vue\` → \`/conferences/participant-count-summary\`
- \`mostCommongIssuesChart.vue\` → \`/issues/summary\`
  - Click-to-detail uses the new \`issue_code=\` filter on \`/conferences\`
- \`gumChart.vue\` → \`/issues/gum-summary\`

Each chart now owns its own loading state, so none of them block on the big \`/conferences\` fetch in app.vue anymore. \`graphsTab.vue\` stops passing \`:conferences\` / \`:issues\` props for these four charts.

## Test plan
- [ ] Open dashboard and confirm all four charts render data without a spinner timeout
- [ ] Click a bar in the duration chart and confirm the modal populates matching conferences
- [ ] Click a slice of the most-common-issues chart and confirm filtered conferences appear
- [ ] Confirm pagination through click-to-detail lists more than 50 rows when applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)