### PR TITLE
feat: migrate connection + session charts to summary endpoints (Phase 4 + 5 of #20)

### DIFF
--- a/static/js/app-dashboard/components/app.vue
+++ b/static/js/app-dashboard/components/app.vue
@@ -109,12 +109,7 @@
         role="tabpanel"
         aria-labelledby="graphs-tab"
       >
-        <graphs-tab
-          :conferences="conferences"
-          :sessions="sessions"
-          :connections="connections"
-          :issues="issues"
-        />
+        <graphs-tab />
       </div>
       <div class="tab-pane fade" id="conferences" role="tabpanel" aria-labelledby="conferences-tab">
         <conferences-tab

--- a/static/js/app-dashboard/components/graphs/callSetupTimeChart.vue
+++ b/static/js/app-dashboard/components/graphs/callSetupTimeChart.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="chart">
-    <NoDataMessage v-if="seriesData.length === 0" />
+    <Loader v-if="loading" />
+    <NoDataMessage v-else-if="isEmpty" />
     <bar-chart
         v-else
         id="call-setup-time-chartjs"
@@ -22,167 +23,108 @@
 import NoDataMessage from "../../../components/noDataMessage.vue";
 import ConferenceListModal from "../../../components/conferenceListModal.vue";
 import BarChart from "../../../components/barChart.vue";
+import Loader from "../../../components/loader.vue";
 
 export default {
   name: "call-setup-time-chart",
-  props: {
-    connections: {
-      type: Array,
-      required: true
-    },
-    conferences: {
-      type: Array,
-      required: true
-    }
-  },
   components: {
     BarChart,
     NoDataMessage,
     ConferenceListModal,
+    Loader,
   },
+
   data() {
     return {
-      durationInverval: [
-        {
-          title: "< 250 ms",
-          min: 0,
-          max: 250,
-          number: 0,
-          data: []
-        },
-        {
-          title: "250 - 500 ms",
-          min: 250,
-          max: 500,
-          number: 0,
-          data: []
-        },
-        {
-          title: "500 - 750 ms",
-          min: 500,
-          max: 750,
-          number: 0,
-          data: []
-        },
-        {
-          title: "750 - 1000 ms",
-          min: 750,
-          max: 1000,
-          number: 0,
-          data: []
-        },
-        {
-          title: "1000 - 1500 ms",
-          min: 1000,
-          max: 1500,
-          number: 0,
-          data: []
-        },
-        {
-          title: "1500 - 2000 ms",
-          min: 1500,
-          max: 2000,
-          number: 0,
-          data: []
-        },
-        {
-          title: "2000 - 2500 ms",
-          min: 2000,
-          max: 2500,
-          number: 0,
-          data: []
-        },
-        {
-          title: "2500 - 3000 ms",
-          min: 2500,
-          max: 3000,
-          number: 0,
-          data: []
-        },
-        {
-          title: "3000 - 4000 ms",
-          min: 3000,
-          max: 4000,
-          number: 0,
-          data: []
-        },
-        {
-          title: "4000 - 5000 ms",
-          min: 4000,
-          max: 5000,
-          number: 0,
-          data: []
-        },
-        {
-          title: "> 5000 ms",
-          min: 5000,
-          max: Infinity,
-          number: 0,
-          data: []
-        }
-      ],
+      loading: true,
+      summary: [],
       modalConferences: [],
     };
   },
 
   computed: {
-    durations() {
-      let confSetupDurations = this.connections.map(connection => {
-        // take all the negociations
-        let negotiations = connection.connection_info['negotiations']
-        // if the first one is not a reneociation
-        if (negotiations && negotiations[0]) {
-          if (negotiations[0].status === 'connected') {
-            // return negotiations[0].duration
-            return {
-              value: new Date(negotiations[0].end_time) - new Date(negotiations[0].start_time),
-              data: connection.conference
-            }
-          }
-        }
-      });
-
-      return peermetrics.utils.groupDurations(
-        confSetupDurations,
-        this.durationInverval
-      );
-    },
     categories() {
-      return this.durations.map(n => n.title);
-    },
-    seriesData() {
-      const hasValues = this.durations.reduce((accumulator, currentValue) => accumulator + currentValue.number, 0)
-
-      if (hasValues) {
-        return {
-          data: this.durations.map((n) => n.number),
-          values: this.durations.map((n) => new Set(n.data))
-        }
-      }
-
-      return []
+      return this.summary.map((b) => b.range);
     },
     series() {
       return [
         {
           label: "Connections",
-          data: this.seriesData.data,
+          data: this.summary.map((b) => b.count),
           backgroundColor: peermetrics.colors.info,
-          values: this.seriesData.values
-        }
+        },
       ];
-    }
+    },
+    isEmpty() {
+      return this.summary.every((b) => b.count === 0);
+    },
+  },
+
+  async mounted() {
+    await this.fetchSummary();
   },
 
   methods: {
-    onChartClick(e) {
-      this.modalConferences = this.conferences.filter((conf) => {
-        return this.seriesData.values[e.index].has(conf.id)
-      });
+    async fetchSummary() {
+      this.loading = true;
+      try {
+        const since = new Date();
+        since.setDate(since.getDate() - peermetrics.daysHistory);
+        const res = await peermetrics.get(peermetrics.urls.connectionsSetupTimeSummary, {
+          appId: peermetrics.app.id,
+          created_at_gte: since.toISOString(),
+        });
+        this.summary = Object.freeze(Array.isArray(res) ? res : (res.data || []));
+      } catch (e) {
+        console.warn(e);
+        this.summary = [];
+      }
+      this.loading = false;
+    },
 
+    async onChartClick(e) {
+      const bucket = this.summary[e.index];
+      if (!bucket || !bucket.conference_ids || bucket.conference_ids.length === 0) {
+        this.modalConferences = [];
+        this.$refs["conferencesModal"].show();
+        return;
+      }
+
+      try {
+        this.modalConferences = await this.fetchConferences(bucket.conference_ids);
+      } catch (err) {
+        console.warn(err);
+        this.modalConferences = [];
+      }
       this.$refs["conferencesModal"].show();
-    }
-  }
+    },
+
+    async fetchConferences(ids) {
+      const PAGE_SIZE = 200;
+      const CHUNK = 100;
+      const out = [];
+
+      for (let start = 0; start < ids.length; start += CHUNK) {
+        const chunk = ids.slice(start, start + CHUNK);
+        let offset = 0;
+        let total = Infinity;
+        while (offset < total) {
+          const res = await peermetrics.get(peermetrics.urls.conferences(), {
+            appId: peermetrics.app.id,
+            conference_ids: chunk.join(','),
+            limit: PAGE_SIZE,
+            offset,
+          });
+          const page = res.results || [];
+          total = typeof res.count === "number" ? res.count : page.length;
+          out.push(...page);
+          if (page.length === 0) break;
+          offset += page.length;
+        }
+      }
+      return out;
+    },
+  },
 };
 </script>
 <style lang="scss" scoped>

--- a/static/js/app-dashboard/components/graphs/conferenceDurationChart.vue
+++ b/static/js/app-dashboard/components/graphs/conferenceDurationChart.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="chart">
-    <NoDataMessage v-if="seriesData.length < 1" />
+    <Loader v-if="loading" />
+    <NoDataMessage v-else-if="isEmpty" />
     <bar-chart
         v-else
         id="conference-duration-chartjs"
@@ -22,78 +23,111 @@
 import NoDataMessage from "../../../components/noDataMessage.vue";
 import ConferenceListModal from "../../../components/conferenceListModal.vue";
 import BarChart from "../../../components/barChart.vue";
+import Loader from "../../../components/loader.vue";
 
 export default {
   name: "conference-duration-chart",
-  props: {
-    conferences: {
-      type: Array,
-      required: true
-    },
-  },
   components: {
     BarChart,
     NoDataMessage,
     ConferenceListModal,
+    Loader,
   },
 
   data() {
     return {
+      loading: true,
+      summary: [],
       modalConferences: [],
     };
   },
 
   computed: {
-    durations() {
-      // create an array with all the conf durations
-      let confDurations = this.conferences.map((conference) => {
-        return {
-          value: conference.duration / 60,
-          data: conference.id
-        }
-      });
-
-      return peermetrics.utils.groupDurations(
-        confDurations,
-        peermetrics.globals.durationInterval
-      );
-    },
     categories() {
-      return this.durations.map(n => n.title);
-    },
-    seriesData() {
-      const durations = this.durations.reduce((accumulator, currentValue) => accumulator + currentValue.number, 0)
-
-      if (durations) {
-        return {
-          data: this.durations.map((n) => n.number),
-          values: this.durations.map((n) => new Set(n.data))
-        };
-      } else {
-        return [];
-      }
+      return this.summary.map((b) => b.range);
     },
     series() {
       return [
         {
           label: "Conferences",
-          data: this.seriesData.data,
+          data: this.summary.map((b) => b.count),
           backgroundColor: peermetrics.colors.info,
-          values: this.seriesData.values
-        }
+        },
       ];
-    }
+    },
+    isEmpty() {
+      return this.summary.every((b) => b.count === 0);
+    },
+  },
+
+  async mounted() {
+    await this.fetchSummary();
   },
 
   methods: {
-    onChartClick(e) {
-      this.modalConferences = this.conferences.filter((conf) => {
-        return this.seriesData.values[e.index].has(conf.id)
-      });
+    async fetchSummary() {
+      this.loading = true;
+      try {
+        const since = new Date();
+        since.setDate(since.getDate() - peermetrics.daysHistory);
+        const res = await peermetrics.get(peermetrics.urls.conferencesDurationSummary, {
+          appId: peermetrics.app.id,
+          created_at_gte: since.toISOString(),
+        });
+        this.summary = Object.freeze(Array.isArray(res) ? res : (res.data || []));
+      } catch (e) {
+        console.warn(e);
+        this.summary = [];
+      }
+      this.loading = false;
+    },
 
+    async onChartClick(e) {
+      const bucket = this.summary[e.index];
+      if (!bucket) return;
+
+      try {
+        this.modalConferences = await this.fetchAllInBucket(bucket);
+      } catch (err) {
+        console.warn(err);
+        this.modalConferences = [];
+      }
       this.$refs["conferencesModal"].show();
-    }
-  }
+    },
+
+    async fetchAllInBucket(bucket) {
+      const since = new Date();
+      since.setDate(since.getDate() - peermetrics.daysHistory);
+
+      const PAGE_SIZE = 200;
+      const out = [];
+      let offset = 0;
+      let total = Infinity;
+
+      const baseParams = {
+        appId: peermetrics.app.id,
+        created_at_gte: since.toISOString(),
+        duration_gte: bucket.min_sec,
+      };
+      if (bucket.max_sec !== null && bucket.max_sec !== undefined) {
+        baseParams.duration_lt = bucket.max_sec;
+      }
+
+      while (offset < total) {
+        const res = await peermetrics.get(peermetrics.urls.conferences(), {
+          ...baseParams,
+          limit: PAGE_SIZE,
+          offset,
+        });
+        const page = res.results || [];
+        total = typeof res.count === "number" ? res.count : page.length;
+        out.push(...page);
+        if (page.length === 0) break;
+        offset += page.length;
+      }
+      return out;
+    },
+  },
 };
 </script>
 

--- a/static/js/app-dashboard/components/graphs/connectionTypeChart.vue
+++ b/static/js/app-dashboard/components/graphs/connectionTypeChart.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="chart">
-    <NoDataMessage v-if="dataSeries.length===0" />
+    <Loader v-if="loading" />
+    <NoDataMessage v-else-if="dataSeries.length === 0" />
     <pie-chart
         v-else
         id="type-of-connection-chartjs"
@@ -13,66 +14,58 @@
 <script>
 import NoDataMessage from "../../../components/noDataMessage.vue";
 import PieChart from "../../../components/pieChart.vue";
+import Loader from "../../../components/loader.vue";
 
 export default {
   name: "connection-type-chart",
 
-  props: {
-    connections: {
-      type: Array,
-      required: true
-    }
-  },
-
   components: {
     NoDataMessage,
-    PieChart
+    PieChart,
+    Loader,
+  },
+
+  data() {
+    return {
+      loading: true,
+      summary: [],
+    };
   },
 
   computed: {
     dataSeries() {
-      let result = this.connections
-          .map(connection => {
-            // get connection type from each one
-            return connection.type;
-          })
-          // concat the arrays to create one big one
-          .reduce((arr, cur) => {
-            return arr.concat(cur);
-          }, [])
-          // filter out invalid values
-          .filter(arr => !!arr);
-
-      let types = peermetrics.utils.reduce(result);
-
-      let connectionsCount = Object.values(types).reduce((a, b) => a + b, 0);
-
-      let grouping = {
-        'relayed': 0,
-        'direct': 0
-      }
-      // group the connection types into 2 categories
-      for (let key of Object.keys(types)) {
-        const group_key = key === 'relay' ? 'relayed' : 'direct'
-        grouping[group_key] += types[key]
-      }
-
-      let series = []
-      if (connectionsCount) {
-        series.push({
-          name: 'Direct',
-          y: (grouping['direct'] / connectionsCount) * 100,
-          count: grouping['direct']
-        }, {
-          name: 'Relayed',
-          y: (grouping['relayed'] / connectionsCount) * 100,
-          count: grouping['relayed']
-        })
-      }
-
-      return series
+      const total = this.summary.reduce((sum, row) => sum + (row.count || 0), 0);
+      if (!total) return [];
+      return this.summary.map((row) => ({
+        name: row.name,
+        y: (row.count / total) * 100,
+        count: row.count,
+      }));
     }
-  }
+  },
+
+  async mounted() {
+    await this.fetchSummary();
+  },
+
+  methods: {
+    async fetchSummary() {
+      this.loading = true;
+      try {
+        const since = new Date();
+        since.setDate(since.getDate() - peermetrics.daysHistory);
+        const res = await peermetrics.get(peermetrics.urls.connectionsSummary, {
+          appId: peermetrics.app.id,
+          created_at_gte: since.toISOString(),
+        });
+        this.summary = Array.isArray(res) ? res : (res.data || []);
+      } catch (e) {
+        console.warn(e);
+        this.summary = [];
+      }
+      this.loading = false;
+    },
+  },
 };
 </script>
 

--- a/static/js/app-dashboard/components/graphs/gumChart.vue
+++ b/static/js/app-dashboard/components/graphs/gumChart.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="chart">
-    <NoDataMessage v-if="dataSeries.length===0" />
+    <Loader v-if="loading" />
+    <NoDataMessage v-else-if="dataSeries.length === 0" />
     <pie-chart
         v-else
         id="gum-chartjs"
@@ -14,44 +15,57 @@
 <script>
 import NoDataMessage from "../../../components/noDataMessage.vue";
 import PieChart from "../../../components/pieChart.vue";
+import Loader from "../../../components/loader.vue";
 
 export default {
   name: "gum-chart",
-  props: {
-    issues: {
-      type: Array,
-      required: true
-    }
-  },
   components: {
     PieChart,
-    NoDataMessage
+    NoDataMessage,
+    Loader,
   },
+
+  data() {
+    return {
+      loading: true,
+      summary: [],
+    };
+  },
+
   computed: {
     dataSeries() {
-      const numberOfErrors = this.issues.length
-
-      let titles = {}
-      const result = this.issues.map(function(issue) {
-        titles[issue.data.name] = issue.data.message
-        return issue.data.name
-      })
-
-      let gum_warnings = peermetrics.utils.reduce(result);
-
-      let series = [];
-
-      for (let key of Object.keys(gum_warnings)) {
-        series.push({
-          name: titles[key],
-          y: (gum_warnings[key] / numberOfErrors) * 100,
-          count: gum_warnings[key]
-        });
-      }
-
-      return series;
+      const total = this.summary.reduce((sum, row) => sum + (row.count || 0), 0);
+      if (!total) return [];
+      return this.summary.map((row) => ({
+        name: row.message || row.name,
+        y: (row.count / total) * 100,
+        count: row.count,
+      }));
     },
-  }
+  },
+
+  async mounted() {
+    await this.fetchSummary();
+  },
+
+  methods: {
+    async fetchSummary() {
+      this.loading = true;
+      try {
+        const since = new Date();
+        since.setDate(since.getDate() - peermetrics.daysHistory);
+        const res = await peermetrics.get(peermetrics.urls.issuesGumSummary, {
+          appId: peermetrics.app.id,
+          created_at_gte: since.toISOString(),
+        });
+        this.summary = Array.isArray(res) ? res : (res.data || []);
+      } catch (e) {
+        console.warn(e);
+        this.summary = [];
+      }
+      this.loading = false;
+    },
+  },
 };
 </script>
 

--- a/static/js/app-dashboard/components/graphs/mostCommongIssuesChart.vue
+++ b/static/js/app-dashboard/components/graphs/mostCommongIssuesChart.vue
@@ -75,7 +75,7 @@ export default {
           appId: peermetrics.app.id,
           created_at_gte: since.toISOString(),
         });
-        this.summary = Object.freeze(res.data || []);
+        this.summary = Object.freeze(Array.isArray(res) ? res : (res.data || []));
       } catch (e) {
         console.warn(e);
         this.summary = [];

--- a/static/js/app-dashboard/components/graphs/mostCommongIssuesChart.vue
+++ b/static/js/app-dashboard/components/graphs/mostCommongIssuesChart.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="chart">
-    <NoDataMessage v-if="seriesData.length===0 " />
+    <Loader v-if="loading" />
+    <NoDataMessage v-else-if="summary.length === 0" />
 
     <bar-chart
         v-else
@@ -25,76 +26,102 @@
 import NoDataMessage from "../../../components/noDataMessage.vue";
 import ConferenceListModal from "../../../components/conferenceListModal.vue";
 import BarChart from "../../../components/barChart.vue";
+import Loader from "../../../components/loader.vue";
 
 export default {
   name: "most-common-issues-chart",
-  props: {
-    issues: {
-      type: Array,
-      required: true
-    },
-    conferences: {
-      type: Array,
-      required: true
-    }
-  },
   components: {
     BarChart,
     NoDataMessage,
-    ConferenceListModal
+    ConferenceListModal,
+    Loader,
   },
+
   data() {
     return {
-      modalConferences: []
+      loading: true,
+      summary: [],
+      modalConferences: [],
     };
   },
-  computed: {
-    errorCodes() {
-      return this.issues.map((issue) => {
-        return issue.code
-      })
-    },
-    sortedCodes() {
-      return peermetrics.utils.reduce(this.errorCodes)
-    },
-    categories() {
-      return this.seriesData.map(s => s.title)
-    },
-    seriesData() {
-      const issues = {}
-      this.issues.forEach((issue) => {
-        issues[issue.code] = issue
-      })
 
-      return Object.keys(this.sortedCodes).map((key) => {
-        return {
-          y: this.sortedCodes[key],
-          issueCode: key,
-          title: issues[key]?.title,
-        }
-      })
-      .sort((first, second) => second.y - first.y)
+  computed: {
+    categories() {
+      return this.summary.map((row) => row.title || row.code);
     },
     series() {
       return [
         {
           label: "Issues",
-          data: this.seriesData.map(s => s.y),
+          data: this.summary.map((row) => row.count),
           backgroundColor: peermetrics.colors.info,
           barThickness: 20,
-        }
+        },
       ];
     },
   },
 
+  async mounted() {
+    await this.fetchSummary();
+  },
+
   methods: {
-    onChartClick(e) {
-      this.modalConferences = this.conferences.filter((conf) => {
-        return conf.issues && conf.issues.some((issue) => issue.code === this.seriesData.find(s => s.y === e.yValue).issueCode)
-      });
+    async fetchSummary() {
+      this.loading = true;
+      try {
+        const since = new Date();
+        since.setDate(since.getDate() - peermetrics.daysHistory);
+        const res = await peermetrics.get(peermetrics.urls.issuesSummary, {
+          appId: peermetrics.app.id,
+          created_at_gte: since.toISOString(),
+        });
+        this.summary = Object.freeze(res.data || []);
+      } catch (e) {
+        console.warn(e);
+        this.summary = [];
+      }
+      this.loading = false;
+    },
+
+    async onChartClick(e) {
+      const row = this.summary[e.index];
+      if (!row) return;
+
+      try {
+        this.modalConferences = await this.fetchConferencesForIssue(row.code);
+      } catch (err) {
+        console.warn(err);
+        this.modalConferences = [];
+      }
       this.$refs["conferencesModal"].show();
-    }
-  }
+    },
+
+    async fetchConferencesForIssue(issueCode) {
+      const since = new Date();
+      since.setDate(since.getDate() - peermetrics.daysHistory);
+
+      const PAGE_SIZE = 200;
+      const out = [];
+      let offset = 0;
+      let total = Infinity;
+
+      while (offset < total) {
+        const res = await peermetrics.get(peermetrics.urls.conferences(), {
+          appId: peermetrics.app.id,
+          created_at_gte: since.toISOString(),
+          issue_code: issueCode,
+          limit: PAGE_SIZE,
+          offset,
+        });
+        const page = res.results || [];
+        total = typeof res.count === "number" ? res.count : page.length;
+        out.push(...page);
+        if (page.length === 0) break;
+        offset += page.length;
+      }
+      return out;
+    },
+  },
 };
 </script>
 

--- a/static/js/app-dashboard/components/graphs/noParticipantsChart.vue
+++ b/static/js/app-dashboard/components/graphs/noParticipantsChart.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="chart">
-    <NoDataMessage v-if="dataSeries.length===0" />
+    <Loader v-if="loading" />
+    <NoDataMessage v-else-if="dataSeries.length === 0" />
     <pie-chart
         v-else
         id="number-of-participants-chartjs"
@@ -13,41 +14,60 @@
 <script>
 import NoDataMessage from "../../../components/noDataMessage.vue";
 import PieChart from "../../../components/pieChart.vue";
+import Loader from "../../../components/loader.vue";
 
 export default {
   name: "participants-chart",
-  props: {
-    conferences: {
-      type: Array,
-      required: true
-    }
-  },
   components: {
     PieChart,
-    NoDataMessage
+    NoDataMessage,
+    Loader,
   },
 
-  mounted() {},
+  data() {
+    return {
+      loading: true,
+      summary: [],
+    };
+  },
+
   computed: {
     dataSeries() {
-      let arr = this.conferences.map(conf => {
-        return conf.participants_count || (conf.participants ? conf.participants.length : 0);
-      });
-      let participants = peermetrics.utils.reduce(arr);
-      let conferencesCount = this.conferences.length;
-      let series = [];
+      const total = this.summary.reduce((sum, row) => sum + (row.conferences || 0), 0);
+      if (!total) return [];
+      return this.summary.map((row) => ({
+        name: String(row.participants),
+        y: (row.conferences / total) * 100,
+        count: row.conferences,
+      }));
+    },
+  },
 
-      for (let key of Object.keys(participants)) {
-        series.push({
-          name: key,
-          y: (participants[key] / conferencesCount) * 100,
-          count: participants[key]
-        });
+  async mounted() {
+    await this.fetchSummary();
+  },
+
+  methods: {
+    async fetchSummary() {
+      this.loading = true;
+      try {
+        const since = new Date();
+        since.setDate(since.getDate() - peermetrics.daysHistory);
+        const res = await peermetrics.get(
+          peermetrics.urls.conferencesParticipantCountSummary,
+          {
+            appId: peermetrics.app.id,
+            created_at_gte: since.toISOString(),
+          }
+        );
+        this.summary = Array.isArray(res) ? res : (res.data || []);
+      } catch (e) {
+        console.warn(e);
+        this.summary = [];
       }
-
-      return series;
-    }
-  }
+      this.loading = false;
+    },
+  },
 };
 </script>
 

--- a/static/js/app-dashboard/components/graphsTab.vue
+++ b/static/js/app-dashboard/components/graphsTab.vue
@@ -21,8 +21,7 @@
       </div>
       <div class="col">
         <p class="lead">Relayed connections</p>
-        <Loader v-if="connections == null" />
-        <connection-type-chart v-else :connections="connections" />
+        <connection-type-chart />
       </div>
     </div>
 
@@ -36,8 +35,7 @@
     <div class="row mt-3">
       <div class="col">
         <p class="lead">Connection setup time</p>
-        <Loader v-if="(connections == null || conferences == null)" />
-        <call-setup-time-chart v-else :connections="connections" :conferences="conferences" />
+        <call-setup-time-chart />
       </div>
     </div>
 
@@ -51,21 +49,21 @@
     <div class="row mt-3">
       <div class="col">
         <p class="lead">Browsers</p>
-        <Loader v-if="sessions == null" />
-        <browsers-chart v-else :sessions="sessions" />
+        <Loader v-if="loadingSessions" />
+        <browsers-chart v-else :browsers="sessionsSummary.browsers || []" />
       </div>
       <div class="col">
         <p class="lead">Operating systems</p>
-        <Loader v-if="sessions == null" />
-        <o-s-chart v-else :sessions="sessions" />
+        <Loader v-if="loadingSessions" />
+        <o-s-chart v-else :os="sessionsSummary.os || []" />
       </div>
     </div>
 
     <div class="row mt-3">
       <div class="col">
         <p class="lead">Map</p>
-        <Loader v-if="sessions == null" />
-        <map-chart v-else :sessions="sessions" />
+        <Loader v-if="loadingSessions" />
+        <map-chart v-else :cities="sessionsSummary.cities || []" />
       </div>
     </div>
   </div>
@@ -100,32 +98,33 @@ export default {
     BrowsersChart,
     OSChart,
     MapChart,
-    Loader
+    Loader,
   },
-  props: {
-    conferences: {
-      required: false,
-      validator: value => {
-        return Array.isArray(value) || peermetrics.utils.isNull(value)
+  data() {
+    return {
+      loadingSessions: true,
+      sessionsSummary: {},
+    };
+  },
+  async mounted() {
+    await this.fetchSessionsSummary();
+  },
+  methods: {
+    async fetchSessionsSummary() {
+      this.loadingSessions = true;
+      try {
+        const since = new Date();
+        since.setDate(since.getDate() - peermetrics.daysHistory);
+        const res = await peermetrics.get(peermetrics.urls.sessionsSummary, {
+          appId: peermetrics.app.id,
+          created_at_gte: since.toISOString(),
+        });
+        this.sessionsSummary = res || {};
+      } catch (e) {
+        console.warn(e);
+        this.sessionsSummary = {};
       }
-    },
-    sessions: {
-      required: false,
-      validator: value => {
-        return Array.isArray(value) || peermetrics.utils.isNull(value)
-      }
-    },
-    connections: {
-      required: false,
-      validator: value => {
-        return Array.isArray(value) || peermetrics.utils.isNull(value)
-      }
-    },
-    issues: {
-      required: false,
-      validator: value => {
-        return Array.isArray(value) || peermetrics.utils.isNull(value)
-      }
+      this.loadingSessions = false;
     },
   },
 };

--- a/static/js/app-dashboard/components/graphsTab.vue
+++ b/static/js/app-dashboard/components/graphsTab.vue
@@ -3,24 +3,21 @@
     <div class="row mt-3">
       <div class="col">
         <p class="lead">Conferences</p>
-        <Loader v-if="conferences == null" />
-        <conferences-chart v-else :conferences="conferences" />
+        <conferences-chart />
       </div>
     </div>
 
     <div class="row mt-3">
       <div class="col">
         <p class="lead">Most common issues</p>
-        <Loader v-if="(issues == null || conferences == null)" />
-        <most-common-issues-chart v-else :issues="issues" :conferences="conferences" />
+        <most-common-issues-chart />
       </div>
     </div>
 
     <div class="row mt-3">
       <div class="col">
         <p class="lead">Errors getting access to media</p>
-        <Loader v-if="issues == null" />
-        <gum-chart v-else :issues="gumIssues" />
+        <gum-chart />
       </div>
       <div class="col">
         <p class="lead">Relayed connections</p>
@@ -32,11 +29,7 @@
     <div class="row mt-3">
       <div class="col">
         <p class="lead">Conference duration</p>
-        <Loader v-if="conferences == null" />
-        <conference-duration-chart
-          v-else
-          :conferences="conferences"
-        />
+        <conference-duration-chart />
       </div>
     </div>
 
@@ -51,8 +44,7 @@
     <div class="row mt-3">
       <div class="col">
         <p class="lead">Number of participants</p>
-        <Loader v-if="conferences == null" />
-        <no-participants-chart v-else :conferences="conferences" />
+        <no-participants-chart />
       </div>
     </div>
 
@@ -112,7 +104,7 @@ export default {
   },
   props: {
     conferences: {
-      required: true,
+      required: false,
       validator: value => {
         return Array.isArray(value) || peermetrics.utils.isNull(value)
       }
@@ -136,17 +128,6 @@ export default {
       }
     },
   },
-  computed: {
-    gumIssues() {
-      if (this.issues) {
-        return this.issues.filter((issue) => {
-          return issue.code === 'getusermedia_error'
-        })
-      }
-
-      return []
-    }
-  }
 };
 </script>
 

--- a/static/js/components/browsersChart.vue
+++ b/static/js/components/browsersChart.vue
@@ -1,12 +1,11 @@
 <template>
   <div class="chart">
-    <NoDataMessage v-if="dataSeries.series.length===0" />
+    <NoDataMessage v-if="dataSeries.length === 0" />
     <pie-chart
         v-else
         id="browsers-chartjs"
         tooltipTitle="Browsers"
-        :datasets="dataSeries.series"
-        :drilldown="dataSeries.drilldown"
+        :datasets="dataSeries"
         :padding-top="60"
     />
   </div>
@@ -19,69 +18,25 @@ import PieChart from "./pieChart.vue";
 export default {
   name: "browsers-chart",
   props: {
-    sessions: {
+    browsers: {
       type: Array,
-      required: true
-    }
+      required: true,
+    },
   },
   components: {
     PieChart,
-    NoDataMessage
+    NoDataMessage,
   },
-  mounted() {},
   computed: {
     dataSeries() {
-      let systems = [];
-      let drilldown = {};
-      let len = this.sessions.length;
-
-      this.sessions.forEach(function(event) {
-        if (event.platform) {
-          let platform = event.platform;
-          let name = platform.browser.name;
-          let version = platform.browser.version;
-
-          systems.push(name);
-
-          if (version) {
-            if (drilldown[name]) {
-              drilldown[name].push(version);
-            } else {
-              drilldown[name] = [version];
-            }
-          }
-        }
-      });
-
-      systems = peermetrics.utils.reduce(systems, len);
-
-      let series = [];
-      let drilldownSeries = [];
-      for (let browser in systems) {
-        series.push({
-          name: browser,
-          y: systems[browser],
-          drilldown: drilldown[browser] ? browser : null
-        });
-
-        if (drilldown[browser]) {
-          let versions = peermetrics.utils.reduce(
-            drilldown[browser],
-            drilldown[browser].length
-          );
-          drilldownSeries.push({
-            name: browser,
-            id: browser,
-            data: Object.entries(versions)
-          });
-        }
-      }
-
-      return {
-        series,
-        drilldown: drilldownSeries
-      };
-    }
+      const total = this.browsers.reduce((sum, row) => sum + (row.count || 0), 0);
+      if (!total) return [];
+      return this.browsers.map((row) => ({
+        name: row.name,
+        y: (row.count / total) * 100,
+        count: row.count,
+      }));
+    },
   },
 };
 </script>

--- a/static/js/components/mapChart.vue
+++ b/static/js/components/mapChart.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="chart">
-    <NoDataMessage v-if="!dataSeries || dataSeries.citySeries.length === 0 " />
+    <NoDataMessage v-if="!citySeries || citySeries.length === 0" />
     <div v-else id="map-chart"></div>
   </div>
 </template>
@@ -11,87 +11,60 @@ import NoDataMessage from "./noDataMessage.vue";
 export default {
   name: "map-chart",
   props: {
-    sessions: {
+    cities: {
       type: Array,
-      required: true
-    }
+      required: true,
+    },
   },
   components: {
     NoDataMessage,
   },
-  mounted() {
-    this.createMapChart();
-  },
   data() {
     return {
       map: null,
-      countries: null
-    }
+      countries: null,
+    };
   },
   computed: {
-    dataSeries() {
-      let cities = {};
-
-      // keep track of the min and max of occurences
-      let min
-      let max
-
-      this.sessions.map(session => {
-        let city = session.geo_ip.city;
-        let lat = parseFloat(session.geo_ip.latitude);
-        let lon = parseFloat(session.geo_ip.longitude);
-
-        if (city && lat && lon) {
-          if (city in cities) {
-            cities[city].z += 1;
-          } else {
-            cities[city] = {
-              lat: lat,
-              lon: lon,
-              z: 1
-            };
-          }
-
-          min = min ? Math.min(min, cities[city].z) : cities[city].z
-          max = max ? Math.max(max, cities[city].z) : cities[city].z
-        }
+    citySeries() {
+      return this.cities.map((c) => ({
+        name: c.city,
+        lat: c.latitude,
+        lon: c.longitude,
+        z: c.count,
+      }));
+    },
+    bounds() {
+      if (this.citySeries.length === 0) return { min: 0, max: 0 };
+      let min = Infinity;
+      let max = -Infinity;
+      this.citySeries.forEach((c) => {
+        if (c.z < min) min = c.z;
+        if (c.z > max) max = c.z;
       });
-
-      let citySeries = [];
-      for (let city of Object.keys(cities)) {
-        citySeries.push({
-          name: city,
-          lat: cities[city].lat,
-          lon: cities[city].lon,
-          z: cities[city].z
-        });
-      }
-
-      return {
-        citySeries,
-        min,
-        max
-      };
-    }
+      return { min, max };
+    },
+  },
+  mounted() {
+    this.createMapChart();
   },
   methods: {
     async createMapChart() {
-      // if we have not sessions to use
-      if (this.dataSeries.citySeries.length === 0) return
+      if (this.citySeries.length === 0) return;
 
       if (!this.countries) {
-        const prefix = (window.peermetrics && window.peermetrics.settings && window.peermetrics.settings.urlPrefix) || ''
-        const normalizedPrefix = prefix === '/' ? '' : (prefix.endsWith('/') ? prefix.slice(0, -1) : prefix)
-        const countriesUrl = `${normalizedPrefix}/static/data/countries.json`
-        this.countries = await wretch(countriesUrl).get().json()
+        const prefix = (window.peermetrics && window.peermetrics.settings && window.peermetrics.settings.urlPrefix) || '';
+        const normalizedPrefix = prefix === '/' ? '' : (prefix.endsWith('/') ? prefix.slice(0, -1) : prefix);
+        const countriesUrl = `${normalizedPrefix}/static/data/countries.json`;
+        this.countries = await wretch(countriesUrl).get().json();
       }
 
       if (this.map) {
-        this.map.remove()
-        this.map = null
+        this.map.remove();
+        this.map = null;
       }
 
-      const {min, max} = this.dataSeries
+      const { min, max } = this.bounds;
 
       this.map = L.map('map-chart', {
         attributionControl: false,
@@ -99,53 +72,49 @@ export default {
       }).setView([30, 0], 2);
 
       L.geoJson(this.countries, {
-          clickable: false,
-          style: {
-            fillColor: "#fff",
-            fillOpacity: 1,
-            fill: true,
-            // TODO: find a better color
-            color: "#495057",
-            weight: 1,
-            opacity: 1
-        }
-      }).addTo(this.map)
+        clickable: false,
+        style: {
+          fillColor: "#fff",
+          fillOpacity: 1,
+          fill: true,
+          color: "#495057",
+          weight: 1,
+          opacity: 1,
+        },
+      }).addTo(this.map);
 
-      this.dataSeries.citySeries.forEach((city) => {
-        let radius
-        // if this happens, most likely we only have on value
+      this.citySeries.forEach((city) => {
+        let radius;
         if (min === max) {
-          // still, if we have multiple points with the same value, make them a bit smaller
-          radius = this.dataSeries.citySeries.length === 0 ? 30 : 20
+          radius = this.citySeries.length === 0 ? 30 : 20;
         } else {
-          // we should always have a value between 10 and 30
-          radius = ( city.z - min / max - min ) * 30
-          radius = Math.min(Math.max(radius, 10), 30)
+          radius = ((city.z - min) / (max - min)) * 30;
+          radius = Math.min(Math.max(radius, 10), 30);
         }
 
         L.circleMarker([city.lat, city.lon], {
           color: peermetrics.colors.default,
           fillColor: peermetrics.colors.default,
           fillOpacity: 0.5,
-          radius: radius
+          radius: radius,
         })
-        .bindTooltip(`${city.name}<br>Count: ${city.z}`, {
-          direction: 'top'
-        })
-        .addTo(this.map)
-      })
-    }
+          .bindTooltip(`${city.name}<br>Count: ${city.z}`, {
+            direction: 'top',
+          })
+          .addTo(this.map);
+      });
+    },
   },
   watch: {
-    sessions() {
-      this.$nextTick(this.createMapChart)
+    cities() {
+      this.$nextTick(this.createMapChart);
     },
   },
 };
 </script>
 
 <style>
-  #map-chart {
-    min-height: 200px;
-  }
+#map-chart {
+  min-height: 200px;
+}
 </style>

--- a/static/js/components/osChart.vue
+++ b/static/js/components/osChart.vue
@@ -1,12 +1,11 @@
 <template>
   <div class="chart">
-    <NoDataMessage v-if="dataSeries.series.length===0" />
+    <NoDataMessage v-if="dataSeries.length === 0" />
     <pie-chart
         v-else
         id="os-chart-chartjs"
         tooltipTitle="OS"
-        :datasets="dataSeries.series"
-        :drilldown="dataSeries.drilldown"
+        :datasets="dataSeries"
         :padding-top="60"
     />
   </div>
@@ -19,69 +18,25 @@ import PieChart from "./pieChart.vue";
 export default {
   name: "os-chart",
   props: {
-    sessions: {
+    os: {
       type: Array,
-      required: true
-    }
+      required: true,
+    },
   },
   components: {
     PieChart,
-    NoDataMessage
+    NoDataMessage,
   },
-  mounted() {},
   computed: {
     dataSeries() {
-      let systems = [];
-      let drilldown = {};
-      let len = this.sessions.length;
-
-      this.sessions.forEach(function(event) {
-        if (event.platform) {
-          let platform = event.platform;
-          let name = platform.os.name;
-          let version = platform.os.version;
-
-          systems.push(name);
-
-          if (version) {
-            if (drilldown[name]) {
-              drilldown[name].push(version);
-            } else {
-              drilldown[name] = [version];
-            }
-          }
-        }
-      });
-
-      systems = peermetrics.utils.reduce(systems, len);
-
-      let series = [];
-      let drilldownSeries = [];
-      for (let browser in systems) {
-        series.push({
-          name: browser,
-          y: systems[browser],
-          drilldown: drilldown[browser] ? browser : null
-        });
-
-        if (drilldown[browser]) {
-          let versions = peermetrics.utils.reduce(
-            drilldown[browser],
-            drilldown[browser].length
-          );
-          drilldownSeries.push({
-            name: browser,
-            id: browser,
-            data: Object.entries(versions)
-          });
-        }
-      }
-
-      return {
-        series,
-        drilldown: drilldownSeries
-      };
-    }
+      const total = this.os.reduce((sum, row) => sum + (row.count || 0), 0);
+      if (!total) return [];
+      return this.os.map((row) => ({
+        name: row.name,
+        y: (row.count / total) * 100,
+        count: row.count,
+      }));
+    },
   },
 };
 </script>
@@ -91,4 +46,3 @@ export default {
   background-color: white;
 }
 </style>
-

--- a/static/js/peermetrics.js
+++ b/static/js/peermetrics.js
@@ -52,6 +52,9 @@
     conferencesParticipantCountSummary: '/conferences/participant-count-summary',
     issuesSummary: '/issues/summary',
     issuesGumSummary: '/issues/gum-summary',
+    connectionsSummary: '/connections/summary',
+    connectionsSetupTimeSummary: '/connections/setup-time-summary',
+    sessionsSummary: '/sessions/summary',
     conferenceEvents: function (conferenceId) {
       if (!conferenceId) {
         throw new Error('Missing conferenceId')

--- a/static/js/peermetrics.js
+++ b/static/js/peermetrics.js
@@ -48,6 +48,10 @@
       }
     },
     conferencesSummary: '/conferences/summary',
+    conferencesDurationSummary: '/conferences/duration-summary',
+    conferencesParticipantCountSummary: '/conferences/participant-count-summary',
+    issuesSummary: '/issues/summary',
+    issuesGumSummary: '/issues/gum-summary',
     conferenceEvents: function (conferenceId) {
       if (!conferenceId) {
         throw new Error('Missing conferenceId')


### PR DESCRIPTION
## Summary
Depends on [peermetrics/api#27](https://github.com/peermetrics/api/pull/27). **Stacked on top of #28** — will rebase to only show the Phase 4+5 commit (\`7831381\`) once #28 merges.

Final chart migrations. After this, every chart on the graphs tab reads from a server-side aggregate.

- \`connectionTypeChart.vue\` → \`/connections/summary\` (relay vs direct)
- \`callSetupTimeChart.vue\` → \`/connections/setup-time-summary\`. Click-to-detail uses \`conference_ids\` returned per bucket, paged through \`/conferences?conference_ids=…\` (new filter in API PR)
- \`browsersChart.vue\` / \`osChart.vue\` / \`mapChart.vue\` → share a single \`/sessions/summary\` fetch at the \`graphsTab\` level, then each child renders its slice via props. One HTTP call instead of three.
- \`graphsTab.vue\` — drops \`:conferences\` / \`:sessions\` / \`:connections\` / \`:issues\` prop pass-throughs entirely (no chart needs them anymore)
- \`app.vue\` — stops passing those props to \`<graphs-tab>\` (they're unused)

## Test plan
- [ ] Open the graphs tab and confirm every chart renders without props from app.vue
- [ ] Click a bar in call-setup-time and confirm matched conferences open in the modal
- [ ] Confirm browsers / OS / map all show the same tenant's data (driven by the one shared summary fetch)
- [ ] Verify no \`missing argument url\` warnings appear in console (all summary URL keys registered)

🤖 Generated with [Claude Code](https://claude.com/claude-code)